### PR TITLE
fix: LNモード値の型不一致でフィルタが効かない

### DIFF
--- a/js/lamp_graph/lamp_graph_data.js
+++ b/js/lamp_graph/lamp_graph_data.js
@@ -94,7 +94,8 @@ async function loadSongData(internalFileName) {
  * @returns {Promise<Map<string, { clear: number, minbp: number | null }>>} - SHA256をキーとしたスコアデータのMap
  */
 async function getScoresBySha256s(sha256List, selectedLnModeValue) {
-    const queryTemplate = `SELECT sha256, clear, minbp, notes, mode, epg, lpg, egr, lgr FROM score WHERE mode = ${selectedLnModeValue} AND sha256 IN ({placeholders})`;
+    const modeNum = parseInt(selectedLnModeValue, 10);
+    const queryTemplate = `SELECT sha256, clear, minbp, notes, mode, epg, lpg, egr, lgr FROM score WHERE mode = ${modeNum} AND sha256 IN ({placeholders})`;
 
     const scoresMap = await executeBatchQuery(SQL, scoreDbData, queryTemplate, sha256List, (row, result) => {
         const clearValue = Number(row.clear);
@@ -190,7 +191,7 @@ async function processSongScores(songs, selectedLnModeValue) {
     const songsMap = await checkExistSongsBySha256s(sha256List);
     const scoresMap = await getScoresBySha256s(sha256List, 0);
     let scoresMapXn = null
-    if (selectedLnModeValue !== 0) {
+    if (Number(selectedLnModeValue) !== 0) {
         scoresMapXn = await getScoresBySha256s(sha256List, selectedLnModeValue)
     }
     console.log("フェーズ2完了。");

--- a/js/lamp_graph/lamp_graph_ui.js
+++ b/js/lamp_graph/lamp_graph_ui.js
@@ -43,7 +43,7 @@ function setupEventListeners(onSelectionChange, onGraphClick) {
         let selectedLnModeValue;
         for (const radio of lnModeRadios) {
             if (radio.checked) {
-                selectedLnModeValue = radio.value;
+                selectedLnModeValue = Number(radio.value);
                 break;
             }
         }
@@ -53,7 +53,7 @@ function setupEventListeners(onSelectionChange, onGraphClick) {
     // LN mode変更時の処理
     lnModeRadios.forEach(radio => {
         radio.addEventListener('change', async (event) => {
-            const selectedLnModeValue = event.target.value;
+            const selectedLnModeValue = Number(event.target.value);
             const selectedInternalFileName = difficultyTableSelect.value;
 
             console.log(`LNモードが変更されました: ${selectedLnModeValue}`);


### PR DESCRIPTION
## 概要
- LNモードラジオボタンの値が string のまま比較され、デフォルト LN モードでも不要な scoresMapXn 取得が走っていた
- ラジオ取得時に Number() で数値化し、SQL テンプレートリテラルも parseInt でサニタイズ

## 変更点
- `js/lamp_graph/lamp_graph_ui.js`: ラジオ value を Number() で数値化
- `js/lamp_graph/lamp_graph_data.js`: 比較式と SQL テンプレートを数値化対応

## 動作確認
- [ ] ブラウザで http://localhost:8000/ を開いて Lamp Viewer 表示
- [ ] LN/CN/HCN モード切替で正常表示
- [ ] DevTools コンソールに新規エラーなし

## 関連 Issue
- Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)
