### PR TITLE
fix: SQL.Database 管理の統合改修 (close 漏れ + locateFile 統一)

### DIFF
--- a/js/heatmap_generator.js
+++ b/js/heatmap_generator.js
@@ -1,5 +1,5 @@
 // heatmap_generator.js (メイン処理)
-import { scoreDbData, scorelogDbData } from './db_uploader.js';
+import { scoreDbData, scorelogDbData, sqlPromise } from './db_uploader.js';
 import { t } from './i18n.js';
 import { UNIX_TO_MS, HEATMAP_CONFIG } from './constants.js';
 
@@ -17,17 +17,20 @@ function collectRows(stmt) {
 
 async function generateHeatmapData(scoreDbData, scorelogDbData) {
     try {
-        const SQL = await initSqlJs({ locateFile: filename => `/js/${filename}` });
+        // db_uploader.jsで初期化済みのPromiseを再利用（locateFile重複指定を排除）
+        const SQL = await sqlPromise;
         const scoreDb = new SQL.Database(new Uint8Array(scoreDbData));
         const scorelogDb = new SQL.Database(new Uint8Array(scorelogDbData));
 
-        const notesData = generateNotesData(scoreDb);
-        const progressData = generateProgressData(scorelogDb);
-
-        scoreDb.close();
-        scorelogDb.close();
-
-        return { notes: notesData, progress: progressData };
+        try {
+            const notesData = generateNotesData(scoreDb);
+            const progressData = generateProgressData(scorelogDb);
+            return { notes: notesData, progress: progressData };
+        } finally {
+            // エラー発生時もメモリリークを防ぐため確実にクローズ
+            scoreDb.close();
+            scorelogDb.close();
+        }
     } catch (error) {
         console.error("データベース処理エラー:", error);
         throw error;

--- a/js/html_generator.js
+++ b/js/html_generator.js
@@ -1,5 +1,5 @@
 import {generateNotesData} from './heatmap_generator.js'; // ヒートマップ用のノーツ数データを生成する関数をインポート
-import {scoreDbData} from './db_uploader.js'; // スコアデータベースのデータをインポート
+import {scoreDbData, sqlPromise} from './db_uploader.js'; // スコアデータベースのデータとSQL.jsのPromiseをインポート
 import { t } from './i18n.js'; // i18n翻訳関数をインポート
 import { CLEAR_STATUS } from './constants.js'; // 共有定数をインポート
 import { splitIntoChunks, createPlaceholders } from './utils/sql-chunker.js'; // チャンク分割・プレースホルダ生成
@@ -36,60 +36,65 @@ export async function generateHtmlFromJson(jsonOutput, templateFile) {
                     .sort((a, b) => parseInt(b.data.clear) - parseInt(a.data.clear));
                 return { date, titles, allTitles };
             });
-            // SQL.jsを初期化
-            const SQL = await initSqlJs({ locateFile: filename => `/js/${filename}` });
+            // SQL.jsを初期化（db_uploader.jsで初期化済みのPromiseを再利用）
+            const SQL = await sqlPromise;
             // スコアデータベースをUint8Arrayから初期化
             const scoreDb = new SQL.Database(new Uint8Array(scoreDbData));
-            // スコアデータベースからノーツ数データを生成
-            const noteData = await generateNotesData(scoreDb);
-            // ノーツ数データを日付の形式を揃えて整形
-            const formattedNoteData = noteData.map(item => {
-                return {
-                    date: item.date.replace(/-/g, "/"), // 日付のハイフンをスラッシュに置換
-                    value: item.value
+            let html;
+            try {
+                // スコアデータベースからノーツ数データを生成
+                const noteData = await generateNotesData(scoreDb);
+                // ノーツ数データを日付の形式を揃えて整形
+                const formattedNoteData = noteData.map(item => {
+                    return {
+                        date: item.date.replace(/-/g, "/"), // 日付のハイフンをスラッシュに置換
+                        value: item.value
+                    };
+                });
+                // 整形されたノーツ数データを日付をキーとするオブジェクトに変換
+                const notesMap = formattedNoteData.reduce((accumulator, currentItem) => {
+                    accumulator[currentItem.date] = currentItem.value;
+                    return accumulator;
+                }, {});
+
+                // スコア更新用にノーツ数を取得
+                const allSha256s = [...new Set(
+                    sortedJsonOutputWithKeys.flatMap(d => d.allTitles.map(t => t.data.sha256)).filter(Boolean)
+                )];
+                const songNotesMap = querySongNotesMap(scoreDb, allSha256s);
+
+                // 各日付にscore_updatesを追加
+                for (const dateData of sortedJsonOutputWithKeys) {
+                    dateData.score_updates = dateData.allTitles
+                        .filter(t => t.data.new_score > t.data.old_score)
+                        .map(t => {
+                            const notes = songNotesMap.get(t.data.sha256) || 0;
+                            const scoreRate = notes > 0 ? (t.data.new_score / (notes * 2) * 100) : null;
+                            return {
+                                title: t.title,
+                                old_score: t.data.old_score,
+                                new_score: t.data.new_score,
+                                score_rate: scoreRate !== null ? scoreRate.toFixed(2) : null
+                            };
+                        })
+                        .sort((a, b) => (parseFloat(b.score_rate) || 0) - (parseFloat(a.score_rate) || 0));
+                    // allTitlesはテンプレートに不要なので削除
+                    delete dateData.allTitles;
+                }
+
+                // テンプレートにデータを渡してHTMLをレンダリング
+                const i18n = {
+                    history: t('template.history'),
+                    downloadJson: t('template.download_json'),
+                    bpOnly: t('template.bp_only'),
+                    newClear: t('template.new_clear'),
+                    daysPerPage: t('template.days_per_page'),
+                    scoreUpdate: t('template.score_update'),
                 };
-            });
-            // 整形されたノーツ数データを日付をキーとするオブジェクトに変換
-            const notesMap = formattedNoteData.reduce((accumulator, currentItem) => {
-                accumulator[currentItem.date] = currentItem.value;
-                return accumulator;
-            }, {});
-
-            // スコア更新用にノーツ数を取得
-            const allSha256s = [...new Set(
-                sortedJsonOutputWithKeys.flatMap(d => d.allTitles.map(t => t.data.sha256)).filter(Boolean)
-            )];
-            const songNotesMap = querySongNotesMap(scoreDb, allSha256s);
-
-            // 各日付にscore_updatesを追加
-            for (const dateData of sortedJsonOutputWithKeys) {
-                dateData.score_updates = dateData.allTitles
-                    .filter(t => t.data.new_score > t.data.old_score)
-                    .map(t => {
-                        const notes = songNotesMap.get(t.data.sha256) || 0;
-                        const scoreRate = notes > 0 ? (t.data.new_score / (notes * 2) * 100) : null;
-                        return {
-                            title: t.title,
-                            old_score: t.data.old_score,
-                            new_score: t.data.new_score,
-                            score_rate: scoreRate !== null ? scoreRate.toFixed(2) : null
-                        };
-                    })
-                    .sort((a, b) => (parseFloat(b.score_rate) || 0) - (parseFloat(a.score_rate) || 0));
-                // allTitlesはテンプレートに不要なので削除
-                delete dateData.allTitles;
+                html = template.render({ clear_info: sortedJsonOutputWithKeys, clear_status: CLEAR_STATUS, notes: notesMap, i18n: i18n });
+            } finally {
+                scoreDb.close(); // メモリリーク防止のため確実にクローズ
             }
-
-            // テンプレートにデータを渡してHTMLをレンダリング
-            const i18n = {
-                history: t('template.history'),
-                downloadJson: t('template.download_json'),
-                bpOnly: t('template.bp_only'),
-                newClear: t('template.new_clear'),
-                daysPerPage: t('template.days_per_page'),
-                scoreUpdate: t('template.score_update'),
-            };
-            const html = template.render({ clear_info: sortedJsonOutputWithKeys, clear_status: CLEAR_STATUS, notes: notesMap, i18n: i18n });
             return html; // 生成されたHTMLを返す
         } catch (nunjucksError) {
             // Nunjucksテンプレートのエラーをコンソールに出力し、エラーメッセージを含むHTMLを返す


### PR DESCRIPTION
## 概要
- SQL.Database が close されずメモリリークしていた箇所を try/finally で確実 close (#15)
- heatmap_generator / html_generator で別個に呼んでいた `initSqlJs` を `db_uploader.js` の `sqlPromise` 再利用に統一し、`locateFile` の絶対パス問題も解決 (#16)
- 両 Issue は同一ファイルの同一行範囲を触るため統合実装

## 変更点
- `js/html_generator.js`: 自前 `initSqlJs({ locateFile: '/js/${filename}' })` を削除 → `db_uploader.js` から `sqlPromise` を import して再利用、`scoreDb` の生成箇所を `try/finally` で囲み close を確実化
- `js/heatmap_generator.js`: 同様に自前 `initSqlJs` を削除 → `sqlPromise` を import、`scoreDb`/`scorelogDb` の close を `try/finally` 化（エラー時もリークしない）
- `js/db_uploader.js`: 既に `sqlPromise` が export されていたため変更なし

## なぜ
- `html_generator.js:40` の locateFile は `/js/${filename}`（絶対パス + `lib/` ディレクトリ欠落）で、GitHub Pages のサブディレクトリ配信（`/oraja_score_viewer/`）下では sql-wasm.wasm をロードできない
- `html_generator.js` の `scoreDb` は close() が呼ばれず、`processData` クリックごとにメモリリーク
- `heatmap_generator.js` の close() は通常パスでは動くが、エラー時にリーク
- `db_uploader.js` で初期化済みの `sqlPromise` を使い回せば WASM の重複ロードも避けられる（`score_change_to_json.js:26` と同じパターン）

## 動作確認
- [ ] ローカルで `python3 -m http.server` 起動 → 3 DB アップロード → processData
- [ ] Score Log Viewer ヒートマップ表示
- [ ] Lamp Viewer 難易度表選択 + LN/CN/HCN 切替
- [ ] DevTools Network タブで `sql-wasm.wasm` が 1 回だけ取得される (200)
- [ ] DevTools コンソールに新規エラーなし
- [ ] DevTools Memory プロファイルで処理後にリークが残らない（理想）

## 関連 Issue
- Closes #15
- Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)
