### PR TITLE
fix: heatmap_generator のエラーを統合 UI に統一

### DIFF
--- a/js/heatmap_generator.js
+++ b/js/heatmap_generator.js
@@ -2,6 +2,7 @@
 import { scoreDbData, scorelogDbData } from './db_uploader.js';
 import { t } from './i18n.js';
 import { UNIX_TO_MS, HEATMAP_CONFIG } from './constants.js';
+import { showError, hideLoading } from './score_change_to_json.js';
 
 /**
  * SQLステートメントから全行をオブジェクト配列として取得する
@@ -148,7 +149,13 @@ document.getElementById("processData").addEventListener("click", async () => {
         displayCalHeatmap(heatmapData.progress, "cal-heatmap-progress", t('heatmap.progress'), HEATMAP_CONFIG.PROGRESS_LIMIT, HEATMAP_CONFIG.PROGRESS_COLOR_SCHEME, t('heatmap.updates'));
 
     } catch (error) {
-        alert(t('alert.process_error'));
+        console.error("ヒートマップ処理エラー:", error);
+        hideLoading();
+        document.getElementById("upload-area").classList.remove("hidden");
+        showError(
+            error.message || t('alert.process_error'),
+            error.stack
+        );
     }
 });
 

--- a/js/score_change_to_json.js
+++ b/js/score_change_to_json.js
@@ -330,4 +330,4 @@ function hideLoading() {
     }
 }
 
-export { getSha256ToMd5Map };
+export { getSha256ToMd5Map, showError, hideLoading };


### PR DESCRIPTION
## 概要
- heatmap 生成失敗時のエラー UI が alert のみで、ローディング表示が解除されない問題を修正
- score_change_to_json.js の showError/hideLoading を再利用して統合エラー UI に統一

## 変更点
- `js/score_change_to_json.js`: `showError` / `hideLoading` を named export に追加
- `js/heatmap_generator.js`: 自前 `alert` を削除、`showError` / `hideLoading` を import して使用。失敗時に `upload-area` を復帰

## 動作確認
- [ ] 正常系: 3 DB アップロード → processData → Score Log Viewer (heatmap) 表示
- [ ] エラー系: 異常な scorelog.db を渡すなどで heatmap 生成失敗 → エラー UI 表示 + ローディング解除 + 再試行ボタン
- [ ] DevTools コンソールに新規エラーなし

## 関連 Issue
- Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)
