### PR TITLE
feat: Lamp Viewer の No Chart 曲リストに BMS URL / Chart URL 列を表示

### DIFF
--- a/js/lamp_graph/lamp_graph_data.js
+++ b/js/lamp_graph/lamp_graph_data.js
@@ -176,7 +176,9 @@ async function processSongScores(songs, selectedLnModeValue) {
             title: title,
             md5: md5,
             sha256: currentSha256,
-            site_url: site_url
+            site_url: site_url,
+            url: song.url || null,
+            url_diff: song.url_diff || null
         });
 
         if (currentSha256) {
@@ -233,6 +235,8 @@ async function processSongScores(songs, selectedLnModeValue) {
             level: songInfo.level,
             title: songInfo.title,
             site_url: songInfo.site_url,
+            url: songInfo.url,
+            url_diff: songInfo.url_diff,
             md5: songInfo.md5,
             sha256: songInfo.sha256,
             clear: String(clear),

--- a/js/lamp_graph/lamp_graph_renderer.js
+++ b/js/lamp_graph/lamp_graph_renderer.js
@@ -89,11 +89,33 @@ function updateSortIndicators(table) {
 }
 
 /**
+ * URLリンクセル（🔗 または「-」）を生成する
+ * @param {string|null} url - リンク先URL
+ * @returns {HTMLTableCellElement}
+ */
+function createUrlCell(url) {
+    const td = document.createElement('td');
+    td.classList.add('url-cell');
+    if (url) {
+        const link = document.createElement('a');
+        link.href = url;
+        link.textContent = '🔗';
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        td.appendChild(link);
+    } else {
+        td.textContent = '-';
+    }
+    return td;
+}
+
+/**
  * tbodyのみを再描画する
  * @param {HTMLTableElement} table - 対象テーブル
  * @param {Array<object>} songs - 元の曲配列
+ * @param {boolean} noChart - No Chart用（スコア列の代わりにURL2列を表示）
  */
-function createTableBody(table, songs) {
+function createTableBody(table, songs, noChart = false) {
     const oldTbody = table.querySelector('tbody');
     if (oldTbody) oldTbody.remove();
 
@@ -116,6 +138,14 @@ function createTableBody(table, songs) {
             tdTitle.textContent = song.title;
         }
         tr.appendChild(tdTitle);
+
+        // No Chart: プレー記録がないため、代わりにデータ入手用のURL2列を表示
+        if (noChart) {
+            tr.appendChild(createUrlCell(song.url));
+            tr.appendChild(createUrlCell(song.url_diff));
+            tbody.appendChild(tr);
+            return;
+        }
 
         // BP
         const tdBp = document.createElement('td');
@@ -155,46 +185,56 @@ function createTableBody(table, songs) {
 /**
  * 曲リストテーブルを生成する
  * @param {Array<object>} songs - 表示する曲配列
+ * @param {boolean} noChart - No Chart用（スコア列の代わりにURL2列を表示）
  * @returns {HTMLTableElement} 生成されたテーブル要素
  */
-function createSongTable(songs) {
+function createSongTable(songs, noChart = false) {
     const table = document.createElement('table');
     table.classList.add('song-list-table');
 
     const thead = document.createElement('thead');
     const headerRow = document.createElement('tr');
 
-    const columns = [
-        { key: 'title', label: t('lamp.table.title') },
-        { key: 'bp', label: t('lamp.table.bp') },
-        { key: 'notes', label: t('lamp.table.notes') },
-        { key: 'exscore', label: t('lamp.table.exscore') },
-        { key: 'rate', label: t('lamp.table.rate') },
-    ];
+    const columns = noChart
+        ? [
+            { key: 'title', label: t('lamp.table.title'), sortable: true },
+            { key: 'url', label: 'BMS URL' },
+            { key: 'url_diff', label: 'Chart URL' },
+        ]
+        : [
+            { key: 'title', label: t('lamp.table.title'), sortable: true },
+            { key: 'bp', label: t('lamp.table.bp'), sortable: true },
+            { key: 'notes', label: t('lamp.table.notes'), sortable: true },
+            { key: 'exscore', label: t('lamp.table.exscore'), sortable: true },
+            { key: 'rate', label: t('lamp.table.rate'), sortable: true },
+        ];
 
     columns.forEach(col => {
         const th = document.createElement('th');
-        th.setAttribute('data-sort', col.key);
-        if (col.key !== 'title') th.classList.add('numeric-cell');
+        if (col.key !== 'title') th.classList.add(noChart ? 'url-cell' : 'numeric-cell');
 
         const labelSpan = document.createElement('span');
         labelSpan.textContent = col.label;
         th.appendChild(labelSpan);
 
-        const indicator = document.createElement('span');
-        indicator.classList.add('sort-indicator');
-        th.appendChild(indicator);
+        if (col.sortable) {
+            th.setAttribute('data-sort', col.key);
 
-        th.addEventListener('click', () => {
-            if (songListSortState.column === col.key) {
-                songListSortState.ascending = !songListSortState.ascending;
-            } else {
-                songListSortState.column = col.key;
-                songListSortState.ascending = true;
-            }
-            createTableBody(table, songs);
-            updateSortIndicators(table);
-        });
+            const indicator = document.createElement('span');
+            indicator.classList.add('sort-indicator');
+            th.appendChild(indicator);
+
+            th.addEventListener('click', () => {
+                if (songListSortState.column === col.key) {
+                    songListSortState.ascending = !songListSortState.ascending;
+                } else {
+                    songListSortState.column = col.key;
+                    songListSortState.ascending = true;
+                }
+                createTableBody(table, songs, noChart);
+                updateSortIndicators(table);
+            });
+        }
 
         headerRow.appendChild(th);
     });
@@ -202,7 +242,7 @@ function createSongTable(songs) {
     thead.appendChild(headerRow);
     table.appendChild(thead);
 
-    createTableBody(table, songs);
+    createTableBody(table, songs, noChart);
     updateSortIndicators(table);
 
     return table;
@@ -323,7 +363,8 @@ function displaySongList(level, clearStatus, aggregatedData, shortName, songList
     listTitle.textContent = `${shortName}${level} - ${clearName} (${songsToShow.length} songs)`;
     songListArea.appendChild(listTitle);
 
-    const table = createSongTable(songsToShow);
+    // No Chart（clear = -1）はプレー記録が存在しないため、table viewer と同様にURL2列を表示する
+    const table = createSongTable(songsToShow, clearStatus === '-1');
     songListArea.appendChild(table);
 }
 

--- a/style.css
+++ b/style.css
@@ -595,6 +595,11 @@ a:hover {
     word-break: break-word;
 }
 
+.song-list-table .url-cell {
+    text-align: center;
+    width: 80px;
+}
+
 .song-list-table a {
     color: var(--text-primary);
     transition: color var(--transition-fast);


### PR DESCRIPTION
## 概要
- Lamp Viewer で No Chart セグメントをクリックした際の曲リストは、プレー記録が存在しないため BP/Notes/EXスコア/レートが全て「-」で情報量がゼロだった
- 代わりに table viewer と同じ「BMS URL」「Chart URL」の🔗リンク2列を表示し、譜面データの入手に役立てる

## 変更点
- `js/lamp_graph/lamp_graph_data.js`: 難易度表由来の `url` / `url_diff` を曲情報オブジェクトに引き継ぐ
- `js/lamp_graph/lamp_graph_renderer.js`: `clear = -1`（No Chart）の曲リストでスコア列の代わりにURL2列のテーブルを生成。URL列は非ソート、譜面名ソートは維持
- `style.css`: `.song-list-table .url-cell` を追加（🔗を中央揃え、幅80px）

## 動作確認
- [x] ブラウザ（Playwright + 実DB）で Stella 難易度表を選択し No Chart セグメントをクリック → 譜面名 | BMS URL | Chart URL の3列で🔗リンクが正しいURLを指すことを確認
- [x] 🔗アイコンがセル中央揃えで表示されることを確認（computed style: center）
- [x] 通常セグメント（Hard等）は従来どおり BP/Notes/EXスコア/レート列で数値表示されることを確認
- [x] No Chart テーブルで譜面名ソート（昇順/降順）が動作することを確認
- [x] DevTools コンソールに新規エラーなし
- [x] `node --check` 通過、デバッグコード残存なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)